### PR TITLE
Add Foundry setup for Codex

### DIFF
--- a/codex.yaml
+++ b/codex.yaml
@@ -1,0 +1,2 @@
+setup:
+  - ./setup.sh

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+# Install dependencies for Foundry
+apt-get update
+apt-get install -y curl build-essential pkg-config libssl-dev git clang cmake
+
+# Install Foundry
+curl -L https://foundry.paradigm.xyz | bash
+export PATH="\$HOME/.foundry/bin:\$PATH"
+
+# Update Foundry (installs forge and cast)
+~/.foundry/bin/foundryup


### PR DESCRIPTION
## Summary
- add `setup.sh` to install Foundry
- configure Codex to run the setup script via `codex.yaml`

## Testing
- `forge fmt` *(fails: command not found)*
- `forge test` *(fails: command not found)*
- `forge coverage` *(fails: command not found)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.